### PR TITLE
TopSkyMaps concatenator only on main

### DIFF
--- a/.github/workflows/build_topskymaps.yml
+++ b/.github/workflows/build_topskymaps.yml
@@ -2,6 +2,8 @@ name: Build TopSkyMaps
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '.data/TopSkyMaps/**'
 


### PR DESCRIPTION
Adds line to restrict concatenator to run only on push of files within .data/TopSkyMaps when updated on main branch