### PR TITLE
Fix DAVMO Even Odd FPC Error

### DIFF
--- a/OMAE/Plugins/VFPC/Sid.json
+++ b/OMAE/Plugins/VFPC/Sid.json
@@ -105,7 +105,7 @@
             {
                "direction": "EVEN",
                "airways": [
-                  "M318"
+                  "M317"
                ]
             },
             {


### PR DESCRIPTION
Attempt to fix VFPC even/odd errors for traffic routing via DAVMO

Plugin now looks first for M317 and allows even, else is odd via M318