### PR TITLE
Make Workflows Great Again

### DIFF
--- a/.github/workflows/build_GRmaps.yml
+++ b/.github/workflows/build_GRmaps.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - '.data/GroundRadarPluginMaps/**'
 
+concurrency:
+  group: map-build
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_topskymaps.yml
+++ b/.github/workflows/build_topskymaps.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - '.data/TopSkyMaps/**'
 
+concurrency:
+  group: map-build
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When the GRP/TopSky workflows run at the same time, it causes a push conflict.

This change ensures the two workflows run one after the other, preventing this.