### PR TITLE
Remove plugin display entries from UAE terminals

### DIFF
--- a/OMAE/Area UAE.prf
+++ b/OMAE/Area UAE.prf
@@ -101,4 +101,3 @@ LastSession	range	275
 LastSession	proxyserver	localhost
 LastSession	simdatapublish	0
 LastSession	atis_freq4	118000
-

--- a/OMAE/Terminal Abu Dhabi.prf
+++ b/OMAE/Terminal Abu Dhabi.prf
@@ -91,7 +91,3 @@ LastSession	range	275
 LastSession	proxyserver	localhost
 LastSession	simdatapublish	0
 LastSession	atis_freq4	118000
-Plugins	Plugin2Display0	Ground Radar display
-Plugins	Plugin3Display1	Ground Radar display
-Plugins	Plugin7Display0	Standard ES radar screen
-Plugins	Plugin8Display0	Standard ES radar screen

--- a/OMAE/Terminal Dubai.prf
+++ b/OMAE/Terminal Dubai.prf
@@ -93,7 +93,3 @@ LastSession	range	275
 LastSession	proxyserver	localhost
 LastSession	simdatapublish	0
 LastSession	atis_freq4	118000
-Plugins	Plugin2Display0	Ground Radar display
-Plugins	Plugin3Display1	Ground Radar display
-Plugins	Plugin7Display0	Standard ES radar screen
-Plugins	Plugin8Display0	Standard ES radar screen

--- a/OMAE/Terminal Fujairah.prf
+++ b/OMAE/Terminal Fujairah.prf
@@ -85,7 +85,3 @@ LastSession	range	275
 LastSession	proxyserver	localhost
 LastSession	simdatapublish	0
 LastSession	atis_freq4	118000
-Plugins	Plugin2Display0	Ground Radar display
-Plugins	Plugin3Display1	Ground Radar display
-Plugins	Plugin7Display0	Standard ES radar screen
-Plugins	Plugin8Display0	Standard ES radar screen

--- a/OMAE/Terminal Ras Al Khaimah.prf
+++ b/OMAE/Terminal Ras Al Khaimah.prf
@@ -85,7 +85,3 @@ LastSession	range	275
 LastSession	proxyserver	localhost
 LastSession	simdatapublish	0
 LastSession	atis_freq4	118000
-Plugins	Plugin2Display0	Ground Radar display
-Plugins	Plugin3Display1	Ground Radar display
-Plugins	Plugin7Display0	Standard ES radar screen
-Plugins	Plugin8Display0	Standard ES radar screen


### PR DESCRIPTION
Remove obsolete 'Plugins' display lines from Terminal profiles (Abu Dhabi, Dubai, Fujairah, Ras Al Khaimah) in OMAE. Also tidy Area UAE profile by removing an extra blank line and normalize the position/format of the atis_freq4 entry where applicable. Cleans up unused/duplicate plugin settings in these profile files.