### PR TITLE
Add report TOBT info line to profiles

### DIFF
--- a/OMAE/Settings/Aerodrome/OMAA/Profiles.txt
+++ b/OMAE/Settings/Aerodrome/OMAA/Profiles.txt
@@ -5,11 +5,11 @@ ATIS3:vACC Information - arabian-vacc.com
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMAA_1_TWR:50:4
 ATIS2:"Abu Dhabi Tower" - DCL [OMAA]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMAA_1X_TWR:50:4
 ATIS2:"Abu Dhabi Tower" - DCL [OMAA]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMAA_2_TWR:50:4
 ATIS2:"Abu Dhabi Tower"
@@ -17,15 +17,15 @@ ATIS3:Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMAA_AIR_FMP:50:4
 ATIS2:"Abu Dhabi Tower Flow Manager" - DO NOT CONTACT ME!
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMAA_1_GND:20:3
 ATIS2:"Abu Dhabi Ground" - DCL [OMAA]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMAA_1X_GND:20:3
 ATIS2:"Abu Dhabi Ground" - DCL [OMAA]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMAA_2_GND:20:3
 ATIS2:"Abu Dhabi Ground"
@@ -37,14 +37,14 @@ ATIS3:Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMAA_GMC_FMP:20:3
 ATIS2:"Abu Dhabi Ground" - DCL [OMAA]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMAA_DEL:20:2
 ATIS2:"Abu Dhabi Delivery" - DCL [OMAA]
-ATIS3:Request clearance 10 minutes before departure. A-CDM vacdm.vatsim.me
+ATIS3:Report TOBT at vats.im/vdgs | Request clearance 10 minutes before TOBT.
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMAA_GMP_FMP:20:2
 ATIS2:"Abu Dhabi Delivery" - DCL [OMAA]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 END

--- a/OMAE/Settings/Aerodrome/OMDB/Profiles.txt
+++ b/OMAE/Settings/Aerodrome/OMDB/Profiles.txt
@@ -5,11 +5,11 @@ ATIS3:vACC Information - arabian-vacc.com
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDB_1_TWR:50:4
 ATIS2:"Dubai Tower" - DCL [OMDB]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDB_1X_TWR:50:4
 ATIS2:"Dubai Tower" - DCL [OMDB]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDB_2_TWR:50:4
 ATIS2:"Dubai Tower"
@@ -21,15 +21,15 @@ ATIS3:Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDB_AIR_FMP:50:4
 ATIS2:"Dubai Tower Flow Manager" - DO NOT CONTACT ME!
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDB_1_GND:20:3
 ATIS2:"Dubai Ground" - DCL [OMDB]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDB_1X_GND:20:3
 ATIS2:"Dubai Ground" - DCL [OMDB]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDB_2_GND:20:3
 ATIS2:"Dubai Ground"
@@ -37,14 +37,14 @@ ATIS3:Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDB_GMC_FMP:20:3
 ATIS2:"Dubai Ground" - DCL [OMDB]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDB_DEL:20:2
 ATIS2:"Dubai Delivery" - DCL [OMDB]
-ATIS3:Request clearance 10 minutes before departure. A-CDM vacdm.vatsim.me
+ATIS3:Report TOBT at vats.im/vdgs | Request clearance 10 minutes before TOBT.
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDB_GMP_FMP:20:2
 ATIS2:"Dubai Delivery" - DCL [OMDB]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 END

--- a/OMAE/Settings/Aerodrome/OMDW/Profiles.txt
+++ b/OMAE/Settings/Aerodrome/OMDW/Profiles.txt
@@ -5,11 +5,11 @@ ATIS3:vACC Information - arabian-vacc.com
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDW_TWR:50:4
 ATIS2:"Al-Maktoum Tower" - DCL [OMDW]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDW_X_TWR:50:4
 ATIS2:"Al-Maktoum Tower" - DCL [OMDW]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDW_A_TWR:50:4
 ATIS2:"Academy Tower"
@@ -21,11 +21,11 @@ ATIS3:Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDW_GND:20:3
 ATIS2:"Al-Maktoum Ground" - DCL [OMDW]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDW_X_GND:20:3
 ATIS2:"Al-Maktoum Ground" - DCL [OMDW]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDW_I_GND:20:3
 ATIS2:"Academy Apron Information" - DCL [OMDW]

--- a/OMAE/Settings/Aerodrome/OMSJ/Profiles.txt
+++ b/OMAE/Settings/Aerodrome/OMSJ/Profiles.txt
@@ -5,10 +5,10 @@ ATIS3:vACC Information - arabian-vacc.com
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMSJ_TWR:50:4
 ATIS2:"Sharjah Tower"
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMSJ_GND:20:3
 ATIS2:"Sharjah Ground"
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 END

--- a/OMAE/Settings/Terminal/Dubai/Profiles.txt
+++ b/OMAE/Settings/Terminal/Dubai/Profiles.txt
@@ -5,11 +5,11 @@ ATIS3:vACC Information - arabian-vacc.com
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDB_APP:150:5
 ATIS2:"Dubai Arrivals" - DCL [OMDA]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDB_X_APP:150:5
 ATIS2:"Dubai Arrivals" - DCL [OMDA]
-ATIS3:Airport Information - vats.im/arb/airports
+ATIS3:Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports
 ATIS4:Give us Feedback (and Karak Chai) - vats.im/arb/feedback
 PROFILE:OMDB_1_DEP:150:5
 ATIS2:"Dubai Departures"


### PR DESCRIPTION
Adds:
`Report TOBT at vats.im/vdgs | Airport Information - vats.im/arb/airports` 
or
`Report TOBT at vats.im/vdgs | Request clearance 10 minutes before TOBT.` (for delivery)

to profiles.txt for Aerodrome and Terminal positions with ATFM procedures.